### PR TITLE
util: add util.parseArgs()

### DIFF
--- a/lib/internal/util/parse_args.js
+++ b/lib/internal/util/parse_args.js
@@ -1,0 +1,149 @@
+'use strict';
+
+const {
+  ArrayIsArray,
+  ArrayPrototypePush,
+  ArrayPrototypeSlice,
+  SafeSet,
+  StringPrototypeReplace,
+  StringPrototypeSplit,
+  StringPrototypeStartsWith,
+} = primordials;
+const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
+
+/**
+ * Returns an Object representation of command-line arguments.
+ *
+ * Default behavior:
+ * - All arguments are considered "boolean flags"; in the `options` property of
+ *   returned object, the key is the argument (if present), and the value will
+ *   be `true`.
+ * - Uses `process.argv.slice(2)`, but can accept an explicit array of strings.
+ * - Argument(s) specified in `opts.optionsWithValue` will have `string` values
+ *   instead of `true`; the subsequent item in the `argv` array will be consumed
+ *   if a `=` is not used
+ * - "Bare" arguments (positionals) are those which do not begin with a `-` or
+ *   `--` and those after a bare `--`; these will be returned as items of the
+ *   `positionals` array
+ * - The `positionals` array will always be present, even if empty.
+ * - The `options` Object will always be present, even if empty.
+ * @param {string[]} [argv=process.argv.slice(2)] - Array of script arguments as
+ * strings
+ * @param {Object} [options] - Options
+ * @param {string[]|string} [options.optionsWithValue] - This argument (or
+ * arguments) expect a value
+ * @param {string[]|string} [options.multiOptions] - This argument (or
+ * arguments) can be specified multiple times and its values will be
+ * concatenated into an array
+ * @returns {{options: Object, positionals: string[]}} Parsed arguments
+ * @example
+ * parseArgs(['--foo', '--bar'])
+ *   // {options: { foo: true, bar: true }, positionals: []}
+ * parseArgs(['--foo', '-b'])
+ *   // {options: { foo: true, b: true }, positionals: []}
+ * parseArgs(['---foo'])
+ *   // {options: { foo: true }, positionals: []}
+ * parseArgs(['--foo=bar'])
+ *   // {options: { foo: true }, positionals: []}
+ * parseArgs([--foo', 'bar'])
+ *   // {options: {foo: true}, positionals: ['bar']}
+ * parseArgs(['--foo', 'bar'], {optionsWithValue: 'foo'})
+ *   // {options: {foo: 'bar'}, positionals: []}
+ * parseArgs(['foo'])
+ *   // {options: {}, positionals: ['foo']}
+ * parseArgs(['--foo', '--', '--bar'])
+ *   // {options: {foo: true}, positionals: ['--bar']}
+ * parseArgs(['--foo=bar', '--foo=baz'])
+ *   // {options: {foo: true}, positionals: []}
+ * parseArgs(['--foo=bar', '--foo=baz'], {optionsWithValue: 'foo'})
+ *   // {options: {foo: 'baz'}, positionals: []}
+ * parseArgs(['--foo=bar', '--foo=baz'], {
+ *   optionsWithValue: 'foo', multiOptions: 'foo'
+ * }) // {options: {foo: ['bar', 'baz']}, positionals: []}
+ * parseArgs(['--foo', '--foo'])
+ *   // {options: {foo: true}, positionals: []}
+ * parseArgs(['--foo', '--foo'], {multiOptions: ['foo']})
+ *   // {options: {foo: [true, true]}, positionals: []}
+ * parseArgs(['--very-wordy-option'])
+ *   // {options: {'very-wordy-option': true}, positionals: []}
+ * parseArgs(['--verbose=false'])
+ *   // {options: {verbose: false}, positionals: []}
+ * parseArgs(['--verbose', 'false'])
+ *   // {options: {verbose: true}, positionals: ['false']}
+ */
+const parseArgs = (
+  argv = ArrayPrototypeSlice(process.argv, 2),
+  options = { optionsWithValue: [] }
+) => {
+  if (!ArrayIsArray(argv)) {
+    options = argv;
+    argv = ArrayPrototypeSlice(process.argv, 2);
+  }
+  if (typeof options !== 'object' || options === null) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'options',
+      'object',
+      options);
+  }
+  if (typeof options.optionsWithValue === 'string') {
+    options.optionsWithValue = [options.optionsWithValue];
+  }
+  if (typeof options.multiOptions === 'string') {
+    options.multiOptions = [options.multiOptions];
+  }
+  const optionsWithValue = new SafeSet(options.optionsWithValue || []);
+  const multiOptions = new SafeSet(options.multiOptions || []);
+  const result = { positionals: [], options: {} };
+
+  let pos = 0;
+  while (pos < argv.length) {
+    const arg = argv[pos];
+    if (StringPrototypeStartsWith(arg, '-')) {
+      // Everything after a bare '--' is considered a positional argument
+      // and is returned verbatim
+      if (arg === '--') {
+        ArrayPrototypePush(
+          result.positionals, ...ArrayPrototypeSlice(argv, ++pos)
+        );
+        return result;
+      }
+      // Any number of leading dashes are allowed
+      const argParts = StringPrototypeSplit(StringPrototypeReplace(arg, /^-+/, ''), '=');
+      const optionName = argParts[0];
+      let optionValue = argParts[1];
+
+      // Consume the next item in the array if `=` was not used
+      // and the next item is not itself a flag or option
+      if (optionsWithValue.has(optionName)) {
+        if (optionValue === undefined) {
+          optionValue = (
+            argv[pos + 1] && StringPrototypeStartsWith(argv[pos + 1], '-')
+          ) || argv[++pos] || '';
+        }
+      } else {
+        // To get a `false` value for a Flag, use e.g., ['--flag=false']
+        optionValue = optionValue !== 'false';
+      }
+
+      if (multiOptions.has(optionName)) {
+        // Consume the next item in the array if `=` was not used
+        // and the next item is not itself a flag or option
+        if (result.options[optionName] === undefined) {
+          result.options[optionName] = [optionValue];
+        } else {
+          ArrayPrototypePush(result.options[optionName], optionValue);
+        }
+      } else if (optionValue !== undefined) {
+        result.options[optionName] = optionValue;
+      }
+    } else {
+      ArrayPrototypePush(result.positionals, arg);
+    }
+    pos++;
+  }
+  return result;
+};
+
+module.exports = {
+  parseArgs
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,6 +64,7 @@ const { validateNumber } = require('internal/validators');
 const { TextDecoder, TextEncoder } = require('internal/encoding');
 const { isBuffer } = require('buffer').Buffer;
 const types = require('internal/util/types');
+const { parseArgs } = require('internal/util/parse_args');
 
 const {
   deprecate,
@@ -282,6 +283,7 @@ module.exports = {
   isFunction,
   isPrimitive,
   log,
+  parseArgs,
   promisify,
   TextDecoder,
   TextEncoder,

--- a/node.gyp
+++ b/node.gyp
@@ -231,6 +231,7 @@
       'lib/internal/util/inspect.js',
       'lib/internal/util/inspector.js',
       'lib/internal/util/iterable_weak_map.js',
+      'lib/internal/util/parse_args.js',
       'lib/internal/util/types.js',
       'lib/internal/http2/core.js',
       'lib/internal/http2/compat.js',

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -96,6 +96,7 @@ const expectedModules = new Set([
   'NativeModule internal/util/debuglog',
   'NativeModule internal/util/inspect',
   'NativeModule internal/util/iterable_weak_map',
+  'NativeModule internal/util/parse_args',
   'NativeModule internal/util/types',
   'NativeModule internal/validators',
   'NativeModule internal/vm/module',

--- a/test/parallel/test-util-parseargs.js
+++ b/test/parallel/test-util-parseargs.js
@@ -1,0 +1,203 @@
+'use strict';
+
+const { invalidArgTypeHelper } = require('../common');
+const assert = require('assert');
+const { format, parseArgs } = require('util');
+
+{
+  const data = new Map([
+    [
+      { argv: ['--foo', '--bar'] },
+      { options: { foo: true, bar: true }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo', '-b'] },
+      { options: { foo: true, b: true }, positionals: [] }
+    ],
+    [
+      { argv: ['---foo'] },
+      { options: { foo: true }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo=bar'] },
+      { options: { foo: true }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo=bar'], opts: { optionsWithValue: ['foo'] } },
+      { options: { foo: 'bar' }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo', 'bar'] },
+      { options: { foo: true }, positionals: ['bar'] }
+    ],
+    [
+      { argv: ['--foo', 'bar'], opts: { optionsWithValue: 'foo' } },
+      { options: { foo: 'bar' }, positionals: [] }
+    ],
+    [
+      { argv: ['foo'] },
+      { options: {}, positionals: ['foo'] }
+    ],
+    [
+      { argv: ['--foo', '--', '--bar'] },
+      { options: { foo: true }, positionals: ['--bar'] }
+    ],
+    [
+      { argv: ['--foo=bar', '--foo=baz'], opts: { optionsWithValue: 'foo' } },
+      { options: { foo: 'baz' }, positionals: [] }
+    ],
+    [
+      {
+        argv: ['--foo=bar', '--foo=baz'],
+        opts: { optionsWithValue: 'foo', multiOptions: 'foo' }
+      },
+      { options: { foo: ['bar', 'baz'] }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo', '--foo'] },
+      { options: { foo: true }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo', '--foo'], opts: { multiOptions: 'foo' } },
+      { options: { foo: [true, true] }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo=true'] },
+      { options: { foo: true }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo=false'] },
+      { options: { foo: false }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo=bar'] },
+      { options: { foo: true }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo', 'true'] },
+      { options: { foo: true }, positionals: ['true'] }
+    ],
+    [
+      { argv: ['--foo', 'false'] },
+      { options: { foo: true }, positionals: ['false'] }
+    ],
+    [
+      { argv: ['--foo', 'true'], opts: { optionsWithValue: ['foo'] } },
+      { options: { foo: 'true' }, positionals: [] }
+    ],
+    [
+      {
+        argv: ['--foo', 'false', 'false'],
+        opts: { optionsWithValue: ['foo'] }
+      },
+      { options: { foo: 'false' }, positionals: ['false'] }
+    ],
+    [
+      { argv: ['--foo=true', '--foo=false'] },
+      { options: { foo: false }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo', 'true', '--foo', 'false'] },
+      { options: { foo: true }, positionals: ['true', 'false'] }
+    ],
+    [
+      { argv: ['--foo', 'true', '--foo', 'false'],
+        opts: { optionsWithValue: 'foo', multiOptions: ['foo'] } },
+      { options: { foo: ['true', 'false'] }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo', 'true', '--foo', 'false'],
+        opts: { optionsWithValue: 'foo' } },
+      { options: { foo: 'false' }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo', 'true', '--foo=false'],
+        opts: { optionsWithValue: 'foo', multiOptions: ['foo'] } },
+      { options: { foo: ['true', 'false'] }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo', 'true', '--foo=false'] },
+      { options: { foo: false }, positionals: ['true'] }
+    ],
+    [
+      {
+        argv: ['--foo', 'bar', '--foo', 'baz'],
+        opts: { optionsWithValue: ['foo'], multiOptions: 'foo' }
+      },
+      { options: { foo: ['bar', 'baz'] }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo', '--bar'], opts: { optionsWithValue: 'foo' } },
+      { options: { foo: true, bar: true }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo=--bar'], opts: { optionsWithValue: 'foo' } },
+      { options: { foo: '--bar' }, positionals: [] }
+    ],
+    [
+      { argv: ['-_'] },
+      { options: { _: true }, positionals: [] }
+    ],
+    [
+      { argv: ['--_=bar'], opts: { optionsWithValue: '_' } },
+      { options: { _: 'bar' }, positionals: [] }
+    ],
+    [
+      { argv: ['--_', 'bar'], opts: { optionsWithValue: '_' } },
+      { options: { _: 'bar' }, positionals: [] }
+    ],
+    [
+      { argv: [], opts: { optionsWithValue: 'foo', multiOptions: 'foo' } },
+      { options: { }, positionals: [] }
+    ],
+    [
+      { argv: [], opts: { multiOptions: 'foo' } },
+      { options: { }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo'], opts: { optionsWithValue: 'foo' } },
+      { options: { foo: '' }, positionals: [] }
+    ]
+  ]);
+
+  data.forEach((output, input) => {
+    const { argv, opts } = input;
+    assert.deepStrictEqual(
+      parseArgs(argv, opts),
+      output,
+      format('%o does not parse to %o', input, output)
+    );
+  });
+}
+
+{
+  // Use of `process.argv.slice(2)` as default `argv` value
+  const originalArgv = process.argv;
+  process.argv = [process.execPath, __filename, '--foo', 'bar'];
+  try {
+    assert.deepStrictEqual(
+      parseArgs(),
+      { options: { foo: true }, positionals: ['bar'] }
+    );
+    assert.deepStrictEqual(
+      parseArgs({ optionsWithValue: 'foo' }),
+      { options: { foo: 'bar' }, positionals: [] }
+    );
+  } finally {
+    process.argv = originalArgv;
+  }
+}
+
+{
+  // error checking
+  const value = 'strings not allowed';
+  assert.throws(() => {
+    parseArgs(value);
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message:
+      'The "options" argument must be of type object.' +
+      invalidArgTypeHelper(value)
+  });
+}


### PR DESCRIPTION
Add a function, `util.parseArgs()`, which accepts an array of
arguments and returns a parsed object representation thereof.

Ref: https://github.com/nodejs/tooling/issues/19

Will update with concerns raised in previous pull request
https://github.com/nodejs/node/pull/35015

I started to capture concerns and such in this HackMD file:
https://hackmd.io/HLpGxK-ST3GLzpOWP4ag_w